### PR TITLE
#184 未登録、非ログインユーザーへの説明の表示を行うウィジェット実装

### DIFF
--- a/qa-plugin.php
+++ b/qa-plugin.php
@@ -1,7 +1,7 @@
 <?php
 
 /*
-	Plugin Name: Welcom Widget Plugin
+	Plugin Name: Welcom Widget
 	Plugin URI:
 	Plugin Description: Welcome the new users.
 	Plugin Version: 1.0
@@ -20,3 +20,5 @@ if (!defined('QA_VERSION')) { // don't allow this page to be requested directly 
 
 // widget
 qa_register_plugin_module('widget', 'qa-welcome-widget.php', 'qa_welcome_widget', 'Welcome Widget');
+// phrases
+qa_register_plugin_phrases('qa-welcome-widget-lang-*.php', 'qa_welcome_widget_lang');

--- a/qa-plugin.php
+++ b/qa-plugin.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+	Plugin Name: Welcom Widget Plugin
+	Plugin URI:
+	Plugin Description: Welcome the new users.
+	Plugin Version: 1.0
+	Plugin Date: 2016-07-29
+	Plugin Author: 38qa.net
+	Plugin Author URI: http://38qa.net/
+	Plugin License: GPLv2
+	Plugin Minimum Question2Answer Version: 1.7
+	Plugin Update Check URI:
+*/
+
+if (!defined('QA_VERSION')) { // don't allow this page to be requested directly from browser
+	header('Location: ../../');
+	exit;
+}
+
+// widget
+qa_register_plugin_module('widget', 'qa-welcome-widget.php', 'qa_welcome_widget', 'Welcome Widget');

--- a/qa-plugin.php
+++ b/qa-plugin.php
@@ -22,3 +22,5 @@ if (!defined('QA_VERSION')) { // don't allow this page to be requested directly 
 qa_register_plugin_module('widget', 'qa-welcome-widget.php', 'qa_welcome_widget', 'Welcome Widget');
 // phrases
 qa_register_plugin_phrases('qa-welcome-widget-lang-*.php', 'qa_welcome_widget_lang');
+// layer
+qa_register_plugin_layer('qa-welcome-widget-layer.php', 'Welcome Widget Layer');

--- a/qa-welcome-widget-lang-default.php
+++ b/qa-welcome-widget-lang-default.php
@@ -1,6 +1,10 @@
-<?
+<?php
+/*
+	Question2Answer Plugin: Welcome Widget
+*/
 	return array(
 		// default
+		'enabled' => 'Enable this plugin.',
 		'custom_html' => 'Custom HTML:',
 		'custom_css' => 'Custom CSS:',
 		'custom_js' => 'Custom Javascript:',

--- a/qa-welcome-widget-lang-default.php
+++ b/qa-welcome-widget-lang-default.php
@@ -1,0 +1,12 @@
+<?
+	return array(
+		// default
+		'custom_html' => 'Custom HTML:',
+		'custom_css' => 'Custom CSS:',
+		'custom_js' => 'Custom Javascript:',
+	);
+
+
+/*
+	Omit PHP closing tag to help avoid accidental output
+*/

--- a/qa-welcome-widget-lang-ja.php
+++ b/qa-welcome-widget-lang-ja.php
@@ -1,0 +1,12 @@
+<?
+	return array(
+		// japanese
+		'custom_html' => 'カスタム HTML:',
+		'custom_css' => 'カスタム CSS:',
+		'custom_js' => 'カスタム Javascript:',
+	);
+
+
+/*
+	Omit PHP closing tag to help avoid accidental output
+*/

--- a/qa-welcome-widget-lang-ja.php
+++ b/qa-welcome-widget-lang-ja.php
@@ -1,6 +1,10 @@
-<?
+<?php
+/*
+	Question2Answer Plugin: Welcome Widget
+*/
 	return array(
 		// japanese
+		'enabled' => 'プラグインを有効にする',
 		'custom_html' => 'カスタム HTML:',
 		'custom_css' => 'カスタム CSS:',
 		'custom_js' => 'カスタム Javascript:',

--- a/qa-welcome-widget-layer.php
+++ b/qa-welcome-widget-layer.php
@@ -1,0 +1,25 @@
+<?php
+
+class qa_html_theme_layer extends qa_html_theme_base
+{
+	public function head_css()
+	{
+		qa_html_theme_base::head_css();
+		if (!qa_is_logged_in()
+			&& $this->template === 'qa'
+			&& qa_opt('qa_welcome_widget_enabled')) {
+			$css = qa_opt('qa_welcome_widget_css');
+			$this->output('<style>', $css, '</style>');
+		}
+	}
+	public function footer()
+	{
+		qa_html_theme_base::footer();
+		if (!qa_is_logged_in()
+			&& $this->template === 'qa'
+			&& qa_opt('qa_welcome_widget_enabled')) {
+			$js = qa_opt('qa_welcome_widget_js');
+			$this->output('<script>', $js, '</script>');
+		}
+   }
+}

--- a/qa-welcome-widget.php
+++ b/qa-welcome-widget.php
@@ -6,6 +6,48 @@
 
 class qa_welcome_widget {
 
+	public function option_default($option)
+	{
+		switch ($option) {
+			case 'qa_welcome_widget_html':
+				return '<p>ここにHTMLを書く</p>';
+			default:
+				return;
+		}
+	}
+
+	public function admin_form(&$qa_content)
+	{
+		// process the admin form if admin hit Save-Changes-button
+		$ok = null;
+		if (qa_clicked('qa_welocome_widget_save')) {
+			qa_opt('qa_welcome_widget_html', qa_post_text('qa_welcome_widget_html'));
+			$ok = qa_lang('admin/options_saved');
+		}
+
+		// form fields to display frontend for admin
+		$fields = array();
+
+		$fields[] = array(
+			'label' => qa_lang('qa_welcome_widget_lang/custom_html'),
+			'tags' => 'NAME="qa_welcome_widget_html"',
+			'value' => qa_opt('qa_welocome_widget_html'),
+			'type' => 'textarea',
+			'rows' => 20
+		);
+
+		return array(
+			'ok' => ($ok && !isset($error)) ? $ok : null,
+			'fields' => $fields,
+			'buttons' => array(
+				array(
+					'label' => qa_lang_html('main/save_button'),
+					'tags' => 'name="qa_welocome_widget_save"',
+				),
+			),
+		);
+	}
+
 	function allow_template($template)
 	{
 		return ($template === 'qa');
@@ -13,33 +55,13 @@ class qa_welcome_widget {
 
 	function allow_region($region)
 	{
-		return ($region === 'main');
+		return ($region === 'full');
 	}
 
 	function output_widget($region, $place, $themeobject, $template, $request, $qa_content)
 	{
-		$requests = explode('/', $request);
-		$tag = $requests[1];
-		$stdb = new similar_tag_db();
-		$tagstring = $stdb->get_similar_tag_words($tag);
-		if(!empty($tagstring)) {
-			$tags = qa_tagstring_to_tags($tagstring);
-
-			$themeobject->output('<div class="qa-q-item-tags"><h4>','関連タグ','</h4>');
-			$themeobject->output('<ul class="qa-q-item-tag-list">');
-			foreach ($tags as $tag) {
-				$themeobject->output('<li class="qa-q-item-tag-item">', $this->add_link($tag), '</li>');
-			}
-			$themeobject->output('</ul>');
-			$themeobject->output('</div>');
-			$themeobject->output('<div class="qa-q-item-clear"></div>');
-		}
-	}
-
-	function add_link($tag) {
-		return '<a href="' . qa_path_html('tag/'.$tag) .
-				'" class="qa-tag-link">' .
-				 qa_html($tag) . '</a>';
+		if ($place === 'low' || $place === 'bottom') return;
+		$themeobject->output($request, $region, $place);
 	}
 }
 /*

--- a/qa-welcome-widget.php
+++ b/qa-welcome-widget.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+	Question2Answer Plugin: Welcome Widget
+*/
+
+class qa_welcome_widget {
+
+	function allow_template($template)
+	{
+		return ($template === 'qa');
+	}
+
+	function allow_region($region)
+	{
+		return ($region === 'main');
+	}
+
+	function output_widget($region, $place, $themeobject, $template, $request, $qa_content)
+	{
+		$requests = explode('/', $request);
+		$tag = $requests[1];
+		$stdb = new similar_tag_db();
+		$tagstring = $stdb->get_similar_tag_words($tag);
+		if(!empty($tagstring)) {
+			$tags = qa_tagstring_to_tags($tagstring);
+
+			$themeobject->output('<div class="qa-q-item-tags"><h4>','関連タグ','</h4>');
+			$themeobject->output('<ul class="qa-q-item-tag-list">');
+			foreach ($tags as $tag) {
+				$themeobject->output('<li class="qa-q-item-tag-item">', $this->add_link($tag), '</li>');
+			}
+			$themeobject->output('</ul>');
+			$themeobject->output('</div>');
+			$themeobject->output('<div class="qa-q-item-clear"></div>');
+		}
+	}
+
+	function add_link($tag) {
+		return '<a href="' . qa_path_html('tag/'.$tag) .
+				'" class="qa-tag-link">' .
+				 qa_html($tag) . '</a>';
+	}
+}
+/*
+	Omit PHP closing tag to help avoid accidental output
+*/

--- a/qa-welcome-widget.php
+++ b/qa-welcome-widget.php
@@ -92,8 +92,14 @@ class qa_welcome_widget {
 
 	function output_widget($region, $place, $themeobject, $template, $request, $qa_content)
 	{
-		if ($place === 'low' || $place === 'bottom' || !empty($request)) return;
-		$themeobject->output($request, $region, $place);
+		if (qa_is_logged_in()
+			|| !qa_opt('qa_welcome_widget_enabled')
+			|| $place === 'low' || $place === 'bottom'
+			|| !empty($request)) {
+			return;
+		}
+		$html = qa_opt('qa_welcome_widget_html');
+		$themeobject->output($html);
 	}
 }
 /*

--- a/qa-welcome-widget.php
+++ b/qa-welcome-widget.php
@@ -92,10 +92,12 @@ class qa_welcome_widget {
 
 	function output_widget($region, $place, $themeobject, $template, $request, $qa_content)
 	{
+		$start = qa_get('start');
 		if (qa_is_logged_in()
 			|| !qa_opt('qa_welcome_widget_enabled')
 			|| $place === 'low' || $place === 'bottom'
-			|| !empty($request)) {
+			|| !empty($request)
+			|| !empty($start)) {
 			return;
 		}
 		$html = qa_opt('qa_welcome_widget_html');

--- a/qa-welcome-widget.php
+++ b/qa-welcome-widget.php
@@ -9,8 +9,14 @@ class qa_welcome_widget {
 	public function option_default($option)
 	{
 		switch ($option) {
+			case 'qa_welcome_widget_enabled':
+				return 1;
 			case 'qa_welcome_widget_html':
-				return '<p>ここにHTMLを書く</p>';
+				return '<p>HTML here</p>';
+			case 'qa_welcome_widget_css':
+				return '/* CSS here */';
+			case 'qa_welcome_widget_js':
+				return '// Javascript here';
 			default:
 				return;
 		}
@@ -21,7 +27,10 @@ class qa_welcome_widget {
 		// process the admin form if admin hit Save-Changes-button
 		$ok = null;
 		if (qa_clicked('qa_welocome_widget_save')) {
+			qa_opt('qa_welcome_widget_enabled', (int)qa_post_text('qa_welcome_widget_enabled'));
 			qa_opt('qa_welcome_widget_html', qa_post_text('qa_welcome_widget_html'));
+			qa_opt('qa_welcome_widget_css', qa_post_text('qa_welcome_widget_css'));
+			qa_opt('qa_welcome_widget_js', qa_post_text('qa_welcome_widget_js'));
 			$ok = qa_lang('admin/options_saved');
 		}
 
@@ -29,11 +38,34 @@ class qa_welcome_widget {
 		$fields = array();
 
 		$fields[] = array(
+			'label' => qa_lang('qa_welcome_widget_lang/enabled'),
+			'tags' => 'NAME="qa_welcome_widget_enabled"',
+			'value' => qa_opt('qa_welcome_widget_enabled'),
+			'type' => 'checkbox',
+		);
+
+		$fields[] = array(
 			'label' => qa_lang('qa_welcome_widget_lang/custom_html'),
 			'tags' => 'NAME="qa_welcome_widget_html"',
-			'value' => qa_opt('qa_welocome_widget_html'),
+			'value' => qa_opt('qa_welcome_widget_html'),
 			'type' => 'textarea',
-			'rows' => 20
+			'rows' => 15
+		);
+
+		$fields[] = array(
+			'label' => qa_lang('qa_welcome_widget_lang/custom_css'),
+			'tags' => 'NAME="qa_welcome_widget_css"',
+			'value' => qa_opt('qa_welcome_widget_css'),
+			'type' => 'textarea',
+			'rows' => 15
+		);
+
+		$fields[] = array(
+			'label' => qa_lang('qa_welcome_widget_lang/custom_js'),
+			'tags' => 'NAME="qa_welcome_widget_js"',
+			'value' => qa_opt('qa_welcome_widget_js'),
+			'type' => 'textarea',
+			'rows' => 15
 		);
 
 		return array(
@@ -60,7 +92,7 @@ class qa_welcome_widget {
 
 	function output_widget($region, $place, $themeobject, $template, $request, $qa_content)
 	{
-		if ($place === 'low' || $place === 'bottom') return;
+		if ($place === 'low' || $place === 'bottom' || !empty($request)) return;
 		$themeobject->output($request, $region, $place);
 	}
 }


### PR DESCRIPTION
- 管理画面にオプション追加
  - プラグインを有効にする
  - カスタムHTML
  - カスタムCSS
  - カスタムJavascript
- ウィジェットとして作成
  - トップページに表示（2ページ目以降でない）
  - 非ログイン時 かつ プラグインが有効の時表示
- 管理センター > レイアウトの「表示位置」
  - 「ページ - コンテンツの下」「ページ - フッターの下」の選択肢
    - 選択肢自体は消せなかったので、ウィジェットを表示するときに$placeをチェック
